### PR TITLE
Fail-safe unmount component

### DIFF
--- a/amcharts3-react.js
+++ b/amcharts3-react.js
@@ -171,7 +171,9 @@
     },
 
     componentWillUnmount: function () {
-      this.state.chart.clear();
+      if (this.state.chart) {
+        this.state.chart.clear();
+      }
     },
 
     render: function () {


### PR DESCRIPTION
When makeChart() in componentDidMount() fails then component cannot be correctly unmounted and breaks whole application:

> Uncaught TypeError: Cannot read property 'clear' of null @ ReactCompositeComponent.js:243 
componentWillUnmount	@	amcharts3-react.js:174
unmountComponent	@	ReactCompositeComponent.js:243
unmountComponent	@	ReactReconciler.js:52
...

PR just checks that chart is available before clear().