### PR TITLE
Check NaN values in updateChartObject

### DIFF
--- a/amcharts3-react.js
+++ b/amcharts3-react.js
@@ -89,6 +89,10 @@
     return true;
   }
 
+  function isNaN(x) {
+    return x !== x
+  }
+
   function isEqual(x, y) {
     var xType = getType(x);
     var yType = getType(y);
@@ -103,6 +107,9 @@
 
       case "[object Date]":
         return x.getTime() === y.getTime();
+
+      case "[object Number]":
+        return x === y || (isNaN(x) && isNaN(y))
 
       default:
         return x === y;


### PR DESCRIPTION
Hello

isEqual() function does not consider a NaN values. When some parameter has a NaN value, then chart will be updated every time, even when configuration has not actually changed.

This checking may seem unnecessary, but I really spent a lot of time to profile the code in an attempt to find the cause of slowdowns.

Also PR contains custom implementation of isNaN function, because [standard function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) has a weird behavior. More details at [SO](http://stackoverflow.com/a/32137779).