### PR TITLE
fixes #43: React.createClass is deprecated (create-react-class)

### DIFF
--- a/amcharts3-react.js
+++ b/amcharts3-react.js
@@ -238,7 +238,7 @@
 
   var id = 0;
 
-  AmCharts.React = React.createClass({
+  AmCharts.React = createReactClass({
     getInitialState: function () {
       return {
         id: "__AmCharts_React_" + (++id) + "__",

--- a/examples/webpack-export/example.js
+++ b/examples/webpack-export/example.js
@@ -1,5 +1,6 @@
 var React = require("react");
 var ReactDOM = require("react-dom");
+var createReactClass = require("create-react-class");
 var AmCharts = require("@amcharts/amcharts3-react");
 
 
@@ -25,7 +26,7 @@ function generateData() {
 
 
 // Component which contains the dynamic state for the chart
-var Chart = React.createClass({
+var Chart = createReactClass({
   getInitialState: function () {
     return {
       dataProvider: generateData(),

--- a/examples/webpack-export/package.json
+++ b/examples/webpack-export/package.json
@@ -7,6 +7,7 @@
 
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "create-react-class": "^15.5.2",
 
     "@amcharts/amcharts3-react": "^2.0.0"
   },

--- a/examples/webpack/example.js
+++ b/examples/webpack/example.js
@@ -1,5 +1,6 @@
 var React = require("react");
 var ReactDOM = require("react-dom");
+var createReactClass = require("create-react-class");
 var AmCharts = require("@amcharts/amcharts3-react");
 
 
@@ -25,7 +26,7 @@ function generateData() {
 
 
 // Component which contains the dynamic state for the chart
-var Chart = React.createClass({
+var Chart = createReactClass({
   getInitialState: function () {
     return {
       dataProvider: generateData(),

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -7,6 +7,7 @@
 
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "create-react-class": "^15.5.2",
 
     "@amcharts/amcharts3-react": "^2.0.0"
   },

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 if (typeof window !== "undefined") {
   window.React = require("react");
   window.ReactDOM = require("react-dom");
+  window.createReactClass = require("create-react-class");
 
   require("./amcharts3-react.js");
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "peerDependencies": {
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
+  },
+  "dependencies": {
+    "create-react-class": "^15.5.2"
   }
 }


### PR DESCRIPTION
Second way for fix #43 (using create-react-class). I think this is more _safe_.