### PR TITLE
Fixing deprecation warning of using React.DOM factories

### DIFF
--- a/amcharts3-react.js
+++ b/amcharts3-react.js
@@ -275,7 +275,7 @@
     },
 
     render: function () {
-      return React.DOM.div({
+      return React.createElement("div", {
         id: this.state.id,
         style: {
           width: this.props.width || "100%",


### PR DESCRIPTION
Accessing factories like React.DOM.div has been deprecated and will be removed in v16.0+.