### PR TITLE
Checking if legend destroy exists before clearing a chart on unmount

### DIFF
--- a/amcharts3-react.js
+++ b/amcharts3-react.js
@@ -269,7 +269,10 @@ console.warn("Version 1.0 is outdated. Please upgrade to version 2.0:\nhttps://g
 
     componentWillUnmount: function () {
       if (this.state.chart) {
-        this.state.chart.clear();
+        var chart = this.state.chart;
+        if(chart.legend && chart.legend.destroy){
+          chart.clear();
+        }
       }
     },
 


### PR DESCRIPTION
When component unmounts before chart is completely rendered, in some race scenarios the legend object does not contain the destroy method and thus fails. This commit helps prevent the unmounting from breaking.